### PR TITLE
intro-to-tests: code challenges should use unittest, and import *

### DIFF
--- a/intro-to-tests/intro-to-pytest.md
+++ b/intro-to-tests/intro-to-pytest.md
@@ -228,11 +228,11 @@ def func_that_always_returns_true():
 ### !tests
 ```python
 import unittest
-import main as p
+from main import *
 
 class TestChallenge(unittest.TestCase):
   def test_returns_true(self):
-      self.assertTrue(p.func_that_always_returns_true())
+      self.assertTrue(func_that_always_returns_true())
 ```
 ### !end-tests
 ### !explanation
@@ -274,12 +274,12 @@ def test_returns_true_if_odd():
 
 ```py
 import unittest
-import main as p
+from main import *
 
 class TestPython1(unittest.TestCase):
     def test_returns_true_if_odd(self):
         number = 5
-        result = p.is_odd(number)
+        result = is_odd(number)
         self.assertTrue(result)
 ```
 
@@ -324,12 +324,12 @@ def test_returns_false_if_even():
 
 ```py
 import unittest
-import main as p
+from main import *
 
 class TestPython1(unittest.TestCase):
     def test_returns_false_if_even(self):
         number = 6
-        result = p.is_odd(number)
+        result = is_odd(number)
         self.assertFalse(result)
 ```
 
@@ -363,12 +363,12 @@ def test_returns_None_if_negative():
 
 ```py
 import unittest
-import main as p
+from main import *
 
 class TestPython1(unittest.TestCase):
     def test_returns_None_if_negative(self):
         number = -1000
-        result = p.is_odd(number)
+        result = is_odd(number)
         assert result is None
 ```
 
@@ -401,7 +401,7 @@ def test_raises_runtime_error():
 
 ```py
 import unittest
-import main as p
+from main import *
 
 class TestPython1(unittest.TestCase):
     def test_raises_runtime_error(self):

--- a/intro-to-tests/intro-to-pytest.md
+++ b/intro-to-tests/intro-to-pytest.md
@@ -192,6 +192,18 @@ def test_zero_division():
 | `ZeroDivisionError`       | The kind of exception we expect should be specified here                                      |
 | `1 / 0`                   | In this code block, we should do our **Act** step, or invoke the function we're testing here. |
 
+### !callout-danger
+
+## This Curriculum Uses unittest, Not pytest
+This curriculum teaches pytest, a testing framework that has wide adoption in the Python community. This curriculum's projects will use pytest. However, **the code challenges within this curriculum will use unittest,** a different testing framework. This is due to a limitation in the curriculum tools.
+
+---
+
+Working with unittest, rather than pytest, will have some differences in syntax. However, conceptually, they are the exact same; the structure, error output, error messages, passed test messages, etc. will all be extremely alike.
+
+This curriculum believes in a learner's ability to smoothly work with these differences.
+### !end-callout
+
 ## Check for Understanding
 
 Here, we are displaying the contents of the test.


### PR DESCRIPTION
@audreyandoy the Python code challenges will use unittest, even though we're teaching pytest. Assigning you to this so you have visibility into this kind of big curriculum decision!

I thought through this and decided:
- unittest tests in Learn are more maintainable vs. custom snippets. They are inline!
- from a student perspective, the test output between unittest and pytest _is_ different, but I will declare it as "a skill to work with the dissonance."
- I also think unittest output is readable enough

This PR is actually just refactoring the unittest tests