### PR TITLE
reversed precedence, and made examples without ()

### DIFF
--- a/fundamentals-recap/conditionals-recap.md
+++ b/fundamentals-recap/conditionals-recap.md
@@ -155,13 +155,14 @@ When there are multiple kinds of operators in a single conditional expression, o
 
 This is an abbreviated list of operators in their "operator precedence" order, where 1 has the highest precedence and will be evaluated before the second. 2 has the second-highest precedence and is evaluated before 3, etc.
 
-1. `or`
-1. `and`
-1. `not`
-1. `in`, `not in`, `is`, `is not`, `<`, `<=`, `>`, `>=`, `!=`, `==`
-1. `+`, `-`
-1. `*`, `/`, `//`, `%`
+1. `()`
 1. `**`
+1. `*`, `/`, `//`, `%`
+1. `+`, `-`
+1. `in`, `not in`, `is`, `is not`, `<`, `<=`, `>`, `>=`, `!=`, `==`
+1. `not`
+1. `and`
+1. `or`
 
 Operators in the equal levels of precedence are evaluated left-to-right.
 
@@ -172,12 +173,12 @@ Expressions that are grouped together in parentheses `()` will always only get e
 Consider these examples that all evalute to `True`:
 
 ```python
-( 100 > 3 ) == ( 5 < 6 )
-not ( 3 > 100 )
-( 5 * 5 ) > ( 20 + 4)
-True != ( not True )
-False or (not ( 3 > 100 ))
-False or (( 3 > 100 ) or not False)
+not 6 - 2 * 3
+not 3 > 100
+5 * 5  > 20 + 4
+not True != True 
+not 3 > 100 or False
+3 > 100 or not False or False
 ```
 
 ## Check for Understanding


### PR DESCRIPTION
The precedence list was in the reverse order, and parentheses were used in all the examples. I reversed the precedence list, and wrote examples without parentheses.