### PR TITLE
Ar/git activity relabel

### DIFF
--- a/intro-to-git/activity-git-history.md
+++ b/intro-to-git/activity-git-history.md
@@ -57,6 +57,31 @@ The group members will use these details to name the specific commands needed.
 | 5   | `5JTrA`     | "adds error handling when loading hike data"    | `hike.py`, `test_hike.py`, `list.py`, `test_list.py` | -                         |
 | 6   | `6ee9f`     | "replaces hike report text with new copy"       | `report.py`, `test_report.py`, `hike.py`             | -                         |
 
+### !callout-info
+
+## A Variety of Git Area Names
+
+We have taken the names used for labeling the boxes from the Git command line. Other tools may refer to these regions differently.
+
+<br />
+
+<details>
+   <summary>Let's briefly review what each region represents and some alternative names.</summary>
+
+| Git Label | Synonym | Purpose |
+| --------- | ------- | ------- |
+| Untracked files | Untracked Changes Area | Files that Git sees as newly created. No version of these files exists in the Git Log yet. |
+| Changes not staged for commit | Local Changes Area | Files that are being tracked by Git, and that have been modified, but which haven't yet been added to a pending commit. |
+| Changes to be committed | Staging Area | Files that are being tracked by Git and are part of a pending commit. |
+
+<br />
+
+We might also see the Git Log referred to as the Git History, which is the log of all commits that have been made.
+
+</details>
+
+### !end-callout
+
 ### Instructions
 
 Group members will take turns making one step. During your turn, you should say out loud what your step is, and the Git command that goes with it. Each group member should collaborate, discuss, help, and confirm that the other group members are on the right track.

--- a/intro-to-git/activity-git-history.md
+++ b/intro-to-git/activity-git-history.md
@@ -42,9 +42,9 @@ The group members will use these details to name the specific commands needed.
 ### Part 1 Setup
 
 1. Begin a diagram of Git's areas. Each individual should draw in their own notes a...
-   - box labeled "Untracked Changes Area"
-   - box labeled "Local Changes Area"
-   - box labeled "Staging Area"
+   - box labeled "Untracked files"
+   - box labeled "Changes not staged for commit"
+   - box labeled "Changes to be committed"
    - box labeled "Git Log"
 1. Each individual should pick one of these commits, where each row is a different commit:
 
@@ -63,10 +63,10 @@ Group members will take turns making one step. During your turn, you should say 
 
 These are the steps:
 
-1. Using the information from your selected commit, write down a new file in "Untracked Changes" or a modified file in "Local Changes"
+1. Using the information from your selected commit, write down a new file in "Untracked files" or a modified file in "Changes not staged for commit"
 1. Repeat step 1 until there are no more files to name
-1. Move a file into "Staging," and erase it from its previous area
-1. Repeat step 1 until there are no more files to add to staging
+1. Move a file into "Changes to be committed," and erase it from its previous area
+1. Repeat step 1 until there are no more files to add to "Changes to be committed"
 1. Create a commit with the specified commit message
 1. Write down the commit's commit hash in the "Log"
 


### PR DESCRIPTION
- updates the labels used for the box areas to match the terms used by `git status`
- adds a callout summarizing what each area represents and includes the original labels used in this activity as synonyms (also useful for instructors!)