### PR TITLE
updates playlists to a playlist per page

### DIFF
--- a/intro-to-git/collaborating.md
+++ b/intro-to-git/collaborating.md
@@ -1,6 +1,6 @@
 # Collaborating
 
-<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=4a699cb2-5d73-4252-a42a-acf4011bb3e4&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
+<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=ff9b0873-e36d-4af6-a4f7-ad28017ae447&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
 
 ## Learning Goals
 

--- a/intro-to-git/commits.md
+++ b/intro-to-git/commits.md
@@ -1,6 +1,6 @@
 # Commits
 
-<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=4a699cb2-5d73-4252-a42a-acf4011bb3e4&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
+<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=d2750a5f-d4d5-4aab-a7da-ad28017abcfc&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
 
 ## Learning Goals
 

--- a/intro-to-git/git-setup.md
+++ b/intro-to-git/git-setup.md
@@ -1,6 +1,6 @@
 # Git Setup
 
-<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=4a699cb2-5d73-4252-a42a-acf4011bb3e4&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
+<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=d0d1a604-fdeb-4f89-b851-ad28017a90b1&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
 
 ## Introduction
 

--- a/intro-to-git/intro-to-git-vocab-and-concepts.md
+++ b/intro-to-git/intro-to-git-vocab-and-concepts.md
@@ -1,6 +1,6 @@
 # Intro to Git: Vocab and Concepts
 
-<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=4a699cb2-5d73-4252-a42a-acf4011bb3e4&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
+<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=1c85dff4-64bc-4c52-a38b-ad28017a626e&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
 
 ## Learning Goals
 

--- a/intro-to-git/reviewing-git-history.md
+++ b/intro-to-git/reviewing-git-history.md
@@ -1,6 +1,6 @@
 # Reviewing Git Histories
 
-<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=4a699cb2-5d73-4252-a42a-acf4011bb3e4&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
+<iframe src="https://adaacademy.hosted.panopto.com/Panopto/Pages/Embed.aspx?pid=c8dba268-808a-4c4f-8e9d-ad28017afeef&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405" width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
 
 ## Learning Goals
 


### PR DESCRIPTION
Other learn lessons only have the videos (sometimes multiple,
if they were split into chunks) pertaining to that one lesson in the playlist
at the top of the lesson. Intro to Git had the same single playlist with all
of the videos in that single playlist on every lesson.

This change creates a separate playlist per lesson (even though there's
only one video in each lesson) and places a distinct playlist on each
lesson page.