### PR TITLE
Move project facilitation instructions to instructor doc

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -156,6 +156,10 @@ Standards:
     ContentFiles:
       -
         Type: Lesson
+        UID: 9dcbb90f
+        Path: /representing-data/activity-representing-data.instructor.md 
+      -
+        Type: Lesson
         UID: 88DgSp
         Path: /representing-data/representing-data-in-lists-and-dictionaries.md
       -
@@ -176,12 +180,12 @@ Standards:
         Path: /representing-data/problem-set-representing-data.md
       -
         Type: Lesson
-        UID: 1f3084593d9eed2a8ec8a797cbfdd89b
-        Path: /representing-data/activity-representing-data.md
+        UID: 30086be0-510f-414c-ab8f-3625c4a48548
+        Path: /representing-data/problem-set-sets-and-tuples.md 
       -
         Type: Lesson
-        UID: 30086be0-510f-414c-ab8f-3625c4a48548
-        Path: /representing-data/problem-set-sets-and-tuples.md      
+        UID: 1f3084593d9eed2a8ec8a797cbfdd89b
+        Path: /representing-data/activity-representing-data.md     
   -
     Title: Intro To Tests
     Description: "Packages and Managing Packages, Automated Tests, Intro to pytest, Problem Set: Intro to pytest"

--- a/representing-data/activity-representing-data.instructor.md
+++ b/representing-data/activity-representing-data.instructor.md
@@ -1,0 +1,25 @@
+# Activity: Representing Data
+
+Below are some suggestions for how to facilitate this activity
+
+## Suggested Activity Instructions
+
+Get into small groups. Find an environment where each member is able to share notes with the rest of the group.
+
+For each prompt...
+
+1. Spend 3-5 minutes answering individually, recording your answers in your own notes
+1. Go around the group, sharing answers in 1-3 sentences
+   - Each member should speak at least once. Talk out loud, practice vocabulary, and practice talking through your reasoning and thought process.
+1. Collect any questions that arose, and find the answers with each other
+   - We encourage curiosity, but don't let your group get stuck in the details!
+   - Collecting questions to answer later is also a great strategy
+
+The group should go at their own pace. However, don't get stuck in the details.
+
+When there are 15 minutes remaining, all groups should work on Prompt #5 if they haven't started already.
+
+## How to Review
+
+- Outside of small groups, share answers for the last prompt
+- Spend care talking about the situation and the reasoning behind that data structure

--- a/representing-data/activity-representing-data.md
+++ b/representing-data/activity-representing-data.md
@@ -8,23 +8,6 @@
 
 Our goal is to practice going from word problem to data structure, and to catch each other's mistakes and correct ourselves. At the end of this activity, we should have talked to other humans, and made sure that we can talk about these data structures and why we made them, too.
 
-## Activity Instructions
-
-Get into small groups. Find an environment where each member is able to share notes with the rest of the group.
-
-For each prompt...
-
-1. Spend 3-5 minutes answering individually, recording your answers in your own notes
-1. Go around the group, sharing answers in 1-3 sentences
-   - Each member should speak at least once. Talk out loud, practice vocabulary, and practice talking through your reasoning and thought process.
-1. Collect any questions that arose, and find the answers with each other
-   - We encourage curiosity, but don't let your group get stuck in the details!
-   - Collecting questions to answer later is also a great strategy
-
-The group should go at their own pace. However, don't get stuck in the details.
-
-When there are 15 minutes remaining, all groups should work on Prompt #5 if they haven't started already.
-
 ## Prompts
 
 ### !callout-info
@@ -96,7 +79,3 @@ Feel free to use or be inspired by any of our suggestions.
 1. Items and resources from a game
 1. A catalog of comic books
 
-## How to Review
-
-- Outside of small groups, share answers for the last prompt
-- Spend care talking about the situation and the reasoning behind that data structure


### PR DESCRIPTION
- Adds a prompt about representing data on craigslist allowing students to tie this activity into how data is presenting in web applications
- Removes open ended prompt in the interest of time
- Moves activity instructions to instructor doc to allow instructors flexibility in how the activity is facilitated.