### PR TITLE
Update tdd exercise to use replit

### DIFF
--- a/intro-to-tests/activity-tests.md
+++ b/intro-to-tests/activity-tests.md
@@ -1,3 +1,3 @@
 # Activity: TDD Exercise
 
-Complete Parts 2 and 3 outlined in the readme of the [tdd-exercise repository](https://github.com/AdaGold/tdd-exercise).
+Complete Parts 2 and 3 outlined in the readme of the [tdd-exercise replit](https://replit.com/@adadev/tdd-exercise#README.md).

--- a/intro-to-tests/problem-set-intro-to-pytest.md
+++ b/intro-to-tests/problem-set-intro-to-pytest.md
@@ -16,7 +16,7 @@ Complete all questions below.
 
 ##### !question
 
-Complete Part 1 outlined in the readme of the [tdd-exercise repository](https://github.com/AdaGold/tdd-exercise).
+Complete Part 1 outlined in the **README** of the [tdd-exercise replit](https://replit.com/@adadev/tdd-exercise#README.md).
 
 Record your test cases below.
 

--- a/intro-to-tests/tdd-exercise.instructor.md
+++ b/intro-to-tests/tdd-exercise.instructor.md
@@ -1,15 +1,11 @@
 # TDD Exercise
 
-https://github.com/AdaGold/tdd-exercise
+
+Replit: https://replit.com/@adadev/tdd-exercise#README.md
+
+Old Repo: https://github.com/AdaGold/tdd-exercise, not used because students haven't learned how to collaborate in Git yet.
 
 The TDD Exercise is introduced as part of the problem set (Part 1) and parts 2 and 3 are meant to be a classroom activity. This classroom activity likely needs 2 hours.
 
 Many folks are not familiar with BlackJack. Hopefully by providing the prompt as part of the problem set students will have time to review the rules.
     - If not knowing the rules of blackjack proves to be an impedement to the learning goals, we should probably replace the prompt for this exercise.
-
-As with TDD Ping Pong, a `requirements.txt` is not currently provided. Here are a few suggestions for how to run this exercise related to the `requirements.txt`.
-- We could not use venv and use the globally installed pytest for this exercise
-- We could use venv and install pytest and create a requirements.txt
-- We could create a `requirements.txt` in the repo and model creating a venv and installing the requirements
-
-In C15 and C16 we introduced `requirements.txt` and `venv` with the first project.


### PR DESCRIPTION
TDD Exercise was in a github repo. However, students complete this exercise before they learn how to collaborate using git, so this PR moves in to a replit: https://replit.com/@adadev/tdd-exercise#README.md