### PR TITLE
Fix small typo in last challenge of problemset

### DIFF
--- a/composition/problem-set-composition.md
+++ b/composition/problem-set-composition.md
@@ -99,7 +99,7 @@ print(today.display_temperature())
 * title: Composition
 
 ##### !question
-Composition can be initiated by a single line of code. In this code snippet, which line is responsible for starting the relationship between `Bedroom` and `Area`?
+Composition can be initiated by a single line of code. In this code snippet, which line is responsible for starting the relationship between `Room` and `Area`?
 
 ```python
 1   class Room:


### PR DESCRIPTION
`Bedroom` is styled like a class name in the challenge description, but the class in the code is named `Room`. Update description to match the code.