### PR TITLE
Remove 'Past Adie Study-Skills Testimonials' paragraph 

### DIFF
--- a/what-is-software-development/study-like-a-programmer.md
+++ b/what-is-software-development/study-like-a-programmer.md
@@ -351,14 +351,6 @@ Which of the following is _not_ a category of studying skills that was covered a
 Want a video series we recommend? Consider: ["Crash Course" on study skills](https://www.youtube.com/playlist?list=PL8dPuuaLjXtNcAJRf3bE1IJU6nMfHj86W)
 
 
-
-
-
-
-## Past Adie Study-Skills Testimonials
-
-Every now and then we collect testimonials from graduated Adies who reflected on transitioning from having zero study skills to forging their study patterns. They are collectively located in the ["Student Testimonials" folder](https://drive.google.com/drive/folders/1PBPfla7ZaIaCTy6A3Fa84SHn4kYw4Xf8).
-
 ## Conclusion
 
 Finding your own study style is challenging, but necessary. Luckily, there are a lot of existing resources and ideas, as well as your own understanding of yourself and your own creativity!


### PR DESCRIPTION
In the lesson `What Is Software Development` > `How to Study like a Programmer` the link to the folder of Past Adie Study-Skills Testimonials results in a 404 error and the folder cannot be found on shared drives. 
I'd like to remove this so it can't cause confusion until we recover the old or gather new testimonials.