### PR TITLE
Move out of scope question from "Fundamentals" to "Intro to Dev Environment"

### DIFF
--- a/fundamentals/problem-set-fundamentals-vocabulary.md
+++ b/fundamentals/problem-set-fundamentals-vocabulary.md
@@ -881,55 +881,6 @@ Use the Python interpreter to experiment with code. We can evaluate any expressi
 <!-- Question 29 -->
 <!-- prettier-ignore-start -->
 ### !challenge
-* type: short-answer
-* id: 4jUlbM
-* title: Fundamentals Vocabulary
-##### !question
-
-What is the command line command to open the Python 3 interpreter?
-
-##### !end-question
-##### !answer
-
-python3
-
-##### !end-answer
-### !end-challenge
-<!-- prettier-ignore-end -->
-
-<!-- Question 30 -->
-<!-- prettier-ignore-start -->
-### !challenge
-* type: checkbox
-* id: NU7rOw
-* title: Fundamentals Vocabulary
-##### !question
-
-Imagine that we are running the Python 3 interpreter in a Terminal. What are all of the valid commands or key combinations to exit the interpreter, and return to the command line?
-
-##### !end-question
-##### !options
-
-* `exit()`
-* `close()`
-* `quit()`
-* `ctrl D`
-* `ctrl C`
-
-##### !end-options
-##### !answer
-
-* `exit()`
-* `quit()`
-* `ctrl D`
-
-##### !end-answer
-### !end-challenge
-<!-- prettier-ignore-end -->
-
-<!-- Question 31 -->
-<!-- prettier-ignore-start -->
-### !challenge
 * type: multiple-choice
 * id: 5a5b2aa8-08ef-4a98-bf3c-e1a61461ceaa
 * title: Fundamentals Vocabulary

--- a/intro-to-dev-environment/intro-to-command-line.md
+++ b/intro-to-dev-environment/intro-to-command-line.md
@@ -180,7 +180,10 @@ $ python3
 
 ![Python Command Line Interpreter](../assets/intro-to-dev-environment-command-line-interpreter.gif)
 
-Using the command line interpreter, we can write and execute Python code directly in the interpreter. We can type `quit()` to exit the command line interpreter. The command line interpreter can be useful for debugging and testing out small pieces of code.
+Using the command line interpreter, we can write and execute Python code directly in the interpreter. The command line interpreter can be useful for debugging and testing out small pieces of code. To exit the command line interpreter, we can type one of the following options:
+- `quit()`
+- `exit()`
+- `ctrl` + `d`
 
 To run a Python program stored within a file, we follow the `python3` command with an argument: (the path and) name of the Python script we want to run.
 
@@ -239,14 +242,12 @@ Try using the up and down arrows to scroll, and tapping the `q` key to quit. I
 
 ## Check for Understanding
 
-<!-- Question 1 -->
-
 <!-- prettier-ignore-start -->
 ### !challenge
 
 * type: multiple-choice
 * id: 0d18747d-94a0-4136-85b1-49a1308ef647
-* title: The command line 
+* title: Intro to Command Line 
 
 ##### !question
 
@@ -272,7 +273,53 @@ What is the command line?
 ### !end-challenge
 <!-- prettier-ignore-end -->
 
-<!-- Question Takeaway -->
+<!-- prettier-ignore-start -->
+### !challenge
+* type: short-answer
+* id: 4jUlbM
+* title: Intro to Command Line
+##### !question
+
+What is the command line command to open the Python 3 interpreter?
+
+##### !end-question
+##### !answer
+
+python3
+
+##### !end-answer
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: checkbox
+* id: NU7rOw
+* title: Intro to Command Line
+##### !question
+
+Imagine that we are running the Python 3 interpreter in a Terminal. What are all of the valid commands or key combinations to exit the interpreter, and return to the command line?
+
+##### !end-question
+##### !options
+
+* `exit()`
+* `close()`
+* `quit()`
+* `ctrl D`
+* `ctrl C`
+
+##### !end-options
+##### !answer
+
+* `exit()`
+* `quit()`
+* `ctrl D`
+
+##### !end-answer
+### !end-challenge
+<!-- prettier-ignore-end -->
+
 <!-- prettier-ignore-start -->
 ### !challenge
 * type: paragraph


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/1/181459410160484/project/1205655776549324/task/1208274379085276?focus=true)

Changes:
- Move out of scope python interpreter questions in Fundamentals Vocabulary Problem Set over to 'Intro to Command line' in the 'Intro to dev environment' tile. 
- Add information on other ways to quit the python interpreter to the 'Intro to Command Line' lesson