### PR TITLE
Sample output for get_max_word has extra `[]` in an output example

### DIFF
--- a/higher-order-functions/higher-order-functions-problem-set.md
+++ b/higher-order-functions/higher-order-functions-problem-set.md
@@ -80,7 +80,7 @@ Example inputs and outputs:
 | -- | -- |
 |`[{"word": "hi", "score": 5}, {"word": "how", "score": 9}, {"word": "are", "score": 3}, {"word": "you", "score": 6}]`|`{"word": "how", "score": 9}`|
 |`[{"word": "ada", "score": 4}, {"word": "roar", "score": 4}]`| `{"word": "ada", "score": 4}`|
-|`[{"word": "how", "score": 9}]`|`[{"word": "how", "score": 9}]`|
+|`[{"word": "how", "score": 9}]`|`{"word": "how", "score": 9}`|
 ||
 |`[]`| None|
 ##### !end-question

--- a/higher-order-functions/higher-order-functions-problem-set.md
+++ b/higher-order-functions/higher-order-functions-problem-set.md
@@ -82,7 +82,7 @@ Example inputs and outputs:
 |`[{"word": "ada", "score": 4}, {"word": "roar", "score": 4}]`| `{"word": "ada", "score": 4}`|
 |`[{"word": "how", "score": 9}]`|`{"word": "how", "score": 9}`|
 ||
-|`[]`| None|
+|`[]`| `None`|
 ##### !end-question
 
 ##### !placeholder


### PR DESCRIPTION
- Removes the erroneous `[]` in the output
- uses code format for `None` in empty input case

Asana: https://app.asana.com/1/181459410160484/project/1201700438643002/task/1211534745654517?focus=true