### PR TITLE
Intro to Tests Problem Set - Remove duplicated bullet points in explanations

### DIFF
--- a/intro-to-tests/problem-set-intro-to-pytest.md
+++ b/intro-to-tests/problem-set-intro-to-pytest.md
@@ -821,9 +821,6 @@ E       AttributeError: 'int' object has no attribute 'append'
 main.py:26: AttributeError
 ============================================== short test summary info ==============================================
 FAILED main.py::test_mystery_function - AttributeError: 'int' object has no attribute 'append'
-main.py:26: AttributeError
-============================================== short test summary info ==============================================
-FAILED main.py::test_mystery_function - AttributeError: 'int' object has no attribute 'append'
 ```
 
 * `a = 100, b = 0` shows us with what arguments the function that failed was called.

--- a/intro-to-tests/problem-set-intro-to-pytest.md
+++ b/intro-to-tests/problem-set-intro-to-pytest.md
@@ -565,10 +565,6 @@ FAILED main.py::test_mystery_function - TypeError: mystery_function() takes 0 po
 * The line marked `E` shows _what_ error was encountered.
 * `main.py:31: TypeError` reinforces that a TypeError occurred during the test.
 * In the summary, the `FAILED` notice repeats any error messages from this test and any others which may have been found.
-* The line marked `>` shows the line where the error was encountered.
-* The line marked `E` shows _what_ error was encountered.
-* `main.py:31: TypeError` reinforces that a TypeError occurred during the test.
-* In the summary, the `FAILED` notice repeats any error messages from this test and any others which may have been found.
 ##### !end-explanation
 ### !end-challenge
 <!-- prettier-ignore-end -->
@@ -755,11 +751,6 @@ FAILED main.py::test_mystery_function - assert False
 * `main.py:31: AssertionError` reinforces that an AssertionError occurred during the test.
 * In the summary, the `FAILED` notice repeats any error messages from this test and any others which may have been found.
 
-* The line marked `>` shows the line where the error was encountered.
-* The line marked `E` appearing on the `assert` line indicates the assertion itself failed.
-* `main.py:31: AssertionError` reinforces that an AssertionError occurred during the test.
-* In the summary, the `FAILED` notice repeats any error messages from this test and any others which may have been found.
-
 ##### !end-explanation
 ### !end-challenge
 <!-- prettier-ignore-end -->
@@ -835,11 +826,6 @@ main.py:26: AttributeError
 FAILED main.py::test_mystery_function - AttributeError: 'int' object has no attribute 'append'
 ```
 
-* `a = 100, b = 0` shows us with what arguments the function that failed was called.
-* The line marked `>` shows the line where the error was encountered.
-* The line marked `E` shows _what_ error was encountered.
-* `main.py:26: AttributeError` reinforces that an AttributeError occurred during the test.
-* In the summary, the `FAILED` notice repeats any error messages from this test and any others which may have been found.
 * `a = 100, b = 0` shows us with what arguments the function that failed was called.
 * The line marked `>` shows the line where the error was encountered.
 * The line marked `E` shows _what_ error was encountered.


### PR DESCRIPTION
The source of the duplicates appears to be a wonky merge. I located the [commit](https://github.com/Ada-Developers-Academy/core-unit-1/commit/5a720fb995724bbfde95f0b001233c94c3b3ae23) that originally introduced the duplication, which helped me find an additional duplication (a portion of the error message rather than the explanation itself) that hadn't been reported in these issues. This should address the following 3 issues.

Asana: https://app.asana.com/1/181459410160484/project/1201700438643002/task/1211312454432522?focus=true
(2 related subtasks)
- https://app.asana.com/1/181459410160484/project/1201700438643002/task/1211312354726192?focus=true
- https://app.asana.com/1/181459410160484/project/1201700438643002/task/1211312614821424?focus=true